### PR TITLE
update KtLint to 1.2.1

### DIFF
--- a/.github/renovate-sh.json
+++ b/.github/renovate-sh.json
@@ -1,0 +1,9 @@
+{
+  "onboardingBranch": "github-renovate/configure",
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "gitAuthor": "Renovate Bot <bot@renovateapp.com>",
+  "dependencyDashboardTitle": "Dependency Dashboard",
+  "onboarding": true,
+  "branchPrefix": "github-renovate/",
+  "platform": "github"
+}

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,64 @@
+{
+  "$schema" : "https://docs.renovatebot.com/renovate-schema.json",
+  "extends" : [
+    "config:best-practices",
+    "default:disableRateLimiting"
+  ],
+  "rebaseWhen" : "conflicted",
+  "rebaseLabel" : "rebase",
+  "packageRules" : [
+    {
+      "groupName" : "Kotlin and compiler plugins",
+      "matchPackagePrefixes" : [
+        "org.jetbrains.kotlin:",
+        "com.google.devtools.ksp:",
+        "com.square.anvil:",
+        "dev.drewhamilton.poko:"
+      ]
+    },
+    {
+      "matchPackagePrefixes" : [
+        "com.pinterest.ktlint:"
+      ],
+      "matchCurrentVersion" : "/(?:1\\.[01]\\.1)|(?:0\\.(?:47|48|49|50|)\\..*)/",
+      "enabled" : false
+    },
+    {
+      "groupName" : "KtLint libs",
+      "matchPackagePrefixes" : [
+        "com.pinterest.ktlint:",
+        "com.rickbusarow.ktlint:",
+        "com.rickbusarow.ktrules:"
+      ]
+    },
+    {
+      "matchPackageNames" : [
+        "com.rickbusarow.module-check"
+      ],
+      "automergeStrategy" : "rebase",
+      "matchRepositories" : [
+        "repo.maven.apache.org/maven2",
+        "plugins.gradle.org/m2"
+      ],
+      "rebaseWhen" : "auto",
+      "matchPackagePrefixes" : [
+        "com.rickbusarow.dispatch:",
+        "com.rickbusarow.doks:",
+        "com.rickbusarow.gradle-dependency-sync:",
+        "com.rickbusarow.hermit:",
+        "com.rickbusarow.kase:",
+        "com.rickbusarow.kgx:",
+        "com.rickbusarow.ktlint:",
+        "com.rickbusarow.ktrules:",
+        "com.rickbusarow.mahout:",
+        "com.rickbusarow.modulecheck:"
+      ],
+      "automerge" : true,
+      "automergeType" : "pr"
+    }
+  ],
+  "labels" : [
+    "dependencies",
+    "automerge"
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,22 @@
 # Changelog
 
-## 1.3.2-SNAPSHOT (unreleased)
+## 1.4.0-SNAPSHOT (unreleased)
+
+The default artifact is now updated to [KtLint 1.2.1](https://github.com/pinterest/ktlint/releases/tag/1.2.1).
+
+The published artifacts have been split again.
+
+These artifacts all have the same rule logic, but use different KtLint versions.
+
+| if you use KtLint... |          use the ktrules artifact:          |
+|:--------------------:|:-------------------------------------------:|
+|        0.47.x        | `com.rickbusarow.ktrules:ktrules-47:1.4.0`  |
+|        0.48.x        | `com.rickbusarow.ktrules:ktrules-48:1.4.0`  |
+|        0.49.x        | `com.rickbusarow.ktrules:ktrules-49:1.4.0`  |
+|        0.50.x        | `com.rickbusarow.ktrules:ktrules-50:1.4.0`  |
+|        1.0.x         | `com.rickbusarow.ktrules:ktrules-100:1.4.0` |
+|        1.1.x         | `com.rickbusarow.ktrules:ktrules-110:1.4.0` |
+|        1.2.x         |   `com.rickbusarow.ktrules:ktrules:1.4.0`   |
 
 ## [1.3.1] - 2021-01-03
 

--- a/README.md
+++ b/README.md
@@ -70,13 +70,16 @@ In order to maintain compatibility with older versions of KtLint, KtRules publis
 artifacts which rely upon the different KtLint api versions. You should choose only one of these
 artifacts corresponding to the KtLint version your project is using.
 
-<!--doks maven-artifact:6, current-ktlint-version:1-->
+<!--doks maven-artifact:7, current-ktlint-version:1-->
 
 ```kotlin
 // build.gradle.kts
 dependencies {
-  // Using the current KtLint (1.1.1) apis
+  // Using the current KtLint (1.2.1) apis
   ktlint("com.rickbusarow.ktrules:ktrules:1.3.1")
+
+  // ... or using the KtLint 1.1.x apis
+  ktlint("com.rickbusarow.ktrules:ktrules-110:1.3.1")
 
   // ... or using the KtLint 1.0.x apis
   ktlint("com.rickbusarow.ktrules:ktrules-100:1.3.1")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -79,7 +79,8 @@ val compatSourceSetNames = listOf(
   "compat49",
   "compat50",
   "compat100",
-  "compat110"
+  "compat110",
+  "compat120"
 )
 
 compatSourceSetNames.forEach { ssName ->
@@ -110,13 +111,14 @@ val compat48Api: Configuration by configurations.getting
 val compat49Api: Configuration by configurations.getting
 val compat50Api: Configuration by configurations.getting
 val compat100Api: Configuration by configurations.getting
-
-val compat110: SourceSet by sourceSets.getting
-val compat110Implementation: Configuration by configurations.getting
 val compat110Api: Configuration by configurations.getting
 
+val compat120: SourceSet by sourceSets.getting
+val compat120Implementation: Configuration by configurations.getting
+val compat120Api: Configuration by configurations.getting
+
 sourceSets.named("test") {
-  compileClasspath += compat110.output
+  compileClasspath += compat120.output
   runtimeClasspath += output + compileClasspath
 }
 
@@ -132,6 +134,9 @@ dependencies {
   compat110Api(libs.jetbrains.markdown)
   compat110Api(libs.ktlint110.cli.ruleset.core)
   compat110Api(libs.ktlint110.rule.engine.core)
+  compat120Api(libs.jetbrains.markdown)
+  compat120Api(libs.ktlint110.cli.ruleset.core)
+  compat120Api(libs.ktlint110.rule.engine.core)
   compat47Api(libs.jetbrains.markdown)
   compat47Api(libs.ktlint47.core)
   compat48Api(libs.ec4j.core)
@@ -148,6 +153,7 @@ dependencies {
 
   "compat100CompileOnly"(libs.google.auto.service.annotations)
   "compat110CompileOnly"(libs.google.auto.service.annotations)
+  "compat120CompileOnly"(libs.google.auto.service.annotations)
   "compat47CompileOnly"(libs.google.auto.service.annotations)
   "compat48CompileOnly"(libs.google.auto.service.annotations)
   "compat49CompileOnly"(libs.google.auto.service.annotations)
@@ -180,6 +186,7 @@ dependencies {
   testImplementation(libs.ktlint.ruleset.standard)
   testImplementation(libs.ktlint.test)
   testImplementation(libs.slf4j.api)
+  testImplementation(libs.slf4j.simple)
 }
 
 val VERSION_CURRENT = libs.versions.ktrules.dev.get()
@@ -229,13 +236,14 @@ tasks.named("apiCheck") { mustRunAfter("apiDump") }
 val updateEditorConfigVersion by tasks.registering {
 
   val file = file(".editorconfig")
+  val current = VERSION_CURRENT
 
   doLast {
     val oldText = file.readText()
 
     val reg = """^(ktlint_kt-rules_project_version *?= *?)\S*$""".toRegex(MULTILINE)
 
-    val newText = oldText.replace(reg, "$1$VERSION_CURRENT")
+    val newText = oldText.replace(reg, "$1$current")
 
     if (newText != oldText) {
       file.writeText(newText)
@@ -519,7 +527,11 @@ publishing {
           pom.withXml {
 
             (
-              (asNode().get("dependencies") as groovy.util.NodeList).firstOrNull() as? groovy.util.Node
+              (
+                asNode().get(
+                  "dependencies"
+                ) as groovy.util.NodeList
+                ).firstOrNull() as? groovy.util.Node
                 ?: asNode().appendNode("dependencies")
               )
               .apply {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ jdk = "11"
 jvmTarget = "11"
 kotlin = "1.9.23"
 kotlinApi = "1.7"
-ktlint-lib = "1.1.1"
+ktlint-lib = "1.2.1"
 ktrules-dev = "1.3.2-SNAPSHOT"
 ktrules-released = "1.3.1"
 
@@ -145,20 +145,27 @@ ktlint50-ruleset-experimental = "com.pinterest.ktlint:ktlint-ruleset-experimenta
 ktlint50-ruleset-standard = "com.pinterest.ktlint:ktlint-ruleset-standard:0.50.0"
 ktlint50-test = "com.pinterest.ktlint:ktlint-test:0.50.0"
 
-ktlint100-cli-ruleset-core = "com.pinterest.ktlint:ktlint-cli-ruleset-core:1.1.1"
-ktlint100-rule-engine-core = "com.pinterest.ktlint:ktlint-rule-engine-core:1.1.1"
+ktlint100-cli-ruleset-core = "com.pinterest.ktlint:ktlint-cli-ruleset-core:1.0.1"
+ktlint100-rule-engine-core = "com.pinterest.ktlint:ktlint-rule-engine-core:1.0.1"
 ktlint100-rule-engine = "com.pinterest.ktlint:ktlint-rule-engine:1.0.1"
 ktlint100-ruleset-experimental = "com.pinterest.ktlint:ktlint-ruleset-experimental:1.0.1"
-ktlint100-ruleset-standard = "com.pinterest.ktlint:ktlint-ruleset-standard:1.1.1"
-ktlint100-test = "com.pinterest.ktlint:ktlint-test:1.1.1"
+ktlint100-ruleset-standard = "com.pinterest.ktlint:ktlint-ruleset-standard:1.0.1"
+ktlint100-test = "com.pinterest.ktlint:ktlint-test:1.0.1"
 
-ktlint110-cli = { module = "com.pinterest.ktlint:ktlint-cli", version.ref = "ktlint-lib" }
-ktlint110-cli-ruleset-core = { module = "com.pinterest.ktlint:ktlint-cli-ruleset-core", version.ref = "ktlint-lib" }
-ktlint110-rule-engine-core = { module = "com.pinterest.ktlint:ktlint-rule-engine-core", version.ref = "ktlint-lib" }
-ktlint110-rule-engine = { module = "com.pinterest.ktlint:ktlint-rule-engine", version.ref = "ktlint-lib" }
-ktlint110-ruleset-experimental = { module = "com.pinterest.ktlint:ktlint-ruleset-experimental", version.ref = "ktlint-lib" }
-ktlint110-ruleset-standard = { module = "com.pinterest.ktlint:ktlint-ruleset-standard", version.ref = "ktlint-lib" }
-ktlint110-test = { module = "com.pinterest.ktlint:ktlint-test", version.ref = "ktlint-lib" }
+ktlint110-cli-ruleset-core = "com.pinterest.ktlint:ktlint-cli-ruleset-core:1.1.1"
+ktlint110-rule-engine-core = "com.pinterest.ktlint:ktlint-rule-engine-core:1.1.1"
+ktlint110-rule-engine = "com.pinterest.ktlint:ktlint-rule-engine:1.1.1"
+ktlint110-ruleset-experimental = "com.pinterest.ktlint:ktlint-ruleset-experimental:1.1.1"
+ktlint110-ruleset-standard = "com.pinterest.ktlint:ktlint-ruleset-standard:1.1.1"
+ktlint110-test = "com.pinterest.ktlint:ktlint-test:1.1.1"
+
+ktlint120-cli = { module = "com.pinterest.ktlint:ktlint-cli", version.ref = "ktlint-lib" }
+ktlint120-cli-ruleset-core = { module = "com.pinterest.ktlint:ktlint-cli-ruleset-core", version.ref = "ktlint-lib" }
+ktlint120-rule-engine-core = { module = "com.pinterest.ktlint:ktlint-rule-engine-core", version.ref = "ktlint-lib" }
+ktlint120-rule-engine = { module = "com.pinterest.ktlint:ktlint-rule-engine", version.ref = "ktlint-lib" }
+ktlint120-ruleset-experimental = { module = "com.pinterest.ktlint:ktlint-ruleset-experimental", version.ref = "ktlint-lib" }
+ktlint120-ruleset-standard = { module = "com.pinterest.ktlint:ktlint-ruleset-standard", version.ref = "ktlint-lib" }
+ktlint120-test = { module = "com.pinterest.ktlint:ktlint-test", version.ref = "ktlint-lib" }
 
 ktlint-cli = { module = "com.pinterest.ktlint:ktlint-cli", version.ref = "ktlint-lib" }
 ktlint-cli-ruleset-core = { module = "com.pinterest.ktlint:ktlint-cli-ruleset-core", version.ref = "ktlint-lib" }

--- a/renovate.json
+++ b/renovate.json
@@ -20,14 +20,6 @@
       ],
       "matchCurrentVersion" : "/(?:1\\.0\\.1)|(?:0\\.(?:47|48|49|50|)\\..*)/",
       "enabled" : false
-    },
-    {
-      "matchPackagePatterns" : [
-        "^com\\.pinterest\\.ktlint:(?:[\\w-]+)$",
-        "^com\\.rickbusarow\\.ktlint:(?:[\\w-]+)$",
-        "^com\\.rickbusarow\\.ktrules:(?:[\\w-]+)$"
-      ],
-      "groupName" : "KtLint things"
     }
   ],
   "labels" : [

--- a/src/compat120/kotlin/com/rickbusarow/ktrules/EditorConfigCompat120.kt
+++ b/src/compat120/kotlin/com/rickbusarow/ktrules/EditorConfigCompat120.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2024 Rick Busarow
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rickbusarow.ktrules
+
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfig
+import com.rickbusarow.ktrules.compat.CodeStyleValueCompat
+import com.rickbusarow.ktrules.compat.EditorConfigCompat
+import com.rickbusarow.ktrules.compat.EditorConfigProperty
+import org.ec4j.core.model.Property
+import org.ec4j.core.model.PropertyType
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.CodeStyleValue as KtLintCodeStyleValue
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfigProperty as KtLintEditorConfigProperty
+
+/** */
+class EditorConfigCompat120(private val delegate: EditorConfig) : EditorConfigCompat {
+  override fun <T> get(editorConfigProperty: EditorConfigProperty<T>): T {
+    return delegate[editorConfigProperty.toKtLintProperty120()]
+  }
+
+  override fun <T> getEditorConfigValueOrNull(
+    propertyType: PropertyType<T>,
+    propertyName: String
+  ): T? = delegate.getEditorConfigValueOrNull(propertyType, propertyName)
+
+  override fun contains(propertyName: String): Boolean {
+    return delegate.contains(propertyName)
+  }
+
+  override fun <T> map(mapper: (Property) -> T): Collection<T> {
+    return delegate.map(mapper)
+  }
+}
+
+/** @since 1.1.1 */
+fun <T> EditorConfigProperty<T>.toKtLintProperty120(): KtLintEditorConfigProperty<T> {
+  val editorConfigProperty = this@toKtLintProperty120
+
+  return KtLintEditorConfigProperty(
+    type = editorConfigProperty.type,
+    defaultValue = editorConfigProperty.defaultValue,
+    ktlintOfficialCodeStyleDefaultValue = editorConfigProperty.ktlintOfficialCodeStyleDefaultValue,
+    intellijIdeaCodeStyleDefaultValue = editorConfigProperty.intellijIdeaCodeStyleDefaultValue,
+    androidStudioCodeStyleDefaultValue = editorConfigProperty.androidStudioCodeStyleDefaultValue,
+    propertyMapper = editorConfigProperty.propertyMapper?.let {
+      { property, codeStyleValue ->
+        it.invoke(property, codeStyleValue.toCompatCodeStyleValueCompat())
+      }
+    },
+    propertyWriter = editorConfigProperty.propertyWriter,
+    deprecationWarning = editorConfigProperty.deprecationWarning,
+    deprecationError = editorConfigProperty.deprecationError,
+    name = editorConfigProperty.name
+  )
+}
+
+private fun KtLintCodeStyleValue.toCompatCodeStyleValueCompat(): CodeStyleValueCompat =
+  when (this) {
+    KtLintCodeStyleValue.android_studio -> CodeStyleValueCompat.android_studio
+    KtLintCodeStyleValue.intellij_idea -> CodeStyleValueCompat.intellij_idea
+    KtLintCodeStyleValue.ktlint_official -> CodeStyleValueCompat.ktlint_official
+  }

--- a/src/compat120/kotlin/com/rickbusarow/ktrules/KtRulesRuleSetProviderV3_120.kt
+++ b/src/compat120/kotlin/com/rickbusarow/ktrules/KtRulesRuleSetProviderV3_120.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2024 Rick Busarow
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rickbusarow.ktrules
+
+import com.google.auto.service.AutoService
+import com.pinterest.ktlint.cli.ruleset.core.api.RuleSetProviderV3
+import com.pinterest.ktlint.rule.engine.core.api.RuleProvider
+import com.pinterest.ktlint.rule.engine.core.api.RuleSetId
+import com.rickbusarow.ktrules.compat.RuleProviderCompat
+import com.rickbusarow.ktrules.rules.internal.mapToSet
+
+/** */
+@Suppress("ktlint:standard:class-naming", "ClassNaming")
+@AutoService(RuleSetProviderV3::class)
+class KtRulesRuleSetProviderV3_120 : RuleSetProviderV3(RuleSetId(KtRulesRuleSetProvider.ID)) {
+
+  override fun getRuleProviders(): Set<RuleProvider> {
+
+    return KtRulesRuleSetProvider.getRuleProviders()
+      .mapToSet { it.toKtLintRuleProvider120() }
+  }
+}
+
+/** */
+fun RuleProviderCompat.toKtLintRuleProvider120(): RuleProvider {
+  return RuleProvider { RuleCompat120(createNewRuleInstance()) }
+}

--- a/src/compat120/kotlin/com/rickbusarow/ktrules/RuleCompat120.kt
+++ b/src/compat120/kotlin/com/rickbusarow/ktrules/RuleCompat120.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2024 Rick Busarow
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rickbusarow.ktrules
+
+import com.pinterest.ktlint.rule.engine.core.api.Rule
+import com.pinterest.ktlint.rule.engine.core.api.RuleId
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfig
+import com.rickbusarow.ktrules.compat.RuleCompat
+import com.rickbusarow.ktrules.compat.RuleCompat.VisitorModifierCompat.RunAfterRuleCompat
+import com.rickbusarow.ktrules.compat.RuleCompat.VisitorModifierCompat.RunAfterRuleCompat.ModeCompat.ONLY_WHEN_RUN_AFTER_RULE_IS_LOADED_AND_ENABLED
+import com.rickbusarow.ktrules.compat.RuleCompat.VisitorModifierCompat.RunAfterRuleCompat.ModeCompat.REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED
+import com.rickbusarow.ktrules.compat.RuleCompat.VisitorModifierCompat.RunAsLateAsPossibleCompat
+import com.rickbusarow.ktrules.rules.internal.mapToSet
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+
+/** */
+class RuleCompat120(private val ruleCompat: RuleCompat) : Rule(
+  RuleId("${KtRulesRuleSetProvider.ID}:${ruleCompat.ruleId.value}"),
+  About(
+    maintainer = KtRulesRuleSetProvider.About.MAINTAINER,
+    repositoryUrl = KtRulesRuleSetProvider.About.REPOSITORY_URL,
+    issueTrackerUrl = KtRulesRuleSetProvider.About.ISSUE_TRACKER_URL
+  ),
+  visitorModifiers = ruleCompat.visitorModifiers.mapToSet { visitorModifier ->
+
+    when (visitorModifier) {
+      is RunAfterRuleCompat -> VisitorModifier.RunAfterRule(
+        RuleId("${KtRulesRuleSetProvider.ID}:${visitorModifier.ruleId.value}"),
+        when (visitorModifier.mode) {
+          REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED ->
+            VisitorModifier.RunAfterRule.Mode.REGARDLESS_WHETHER_RUN_AFTER_RULE_IS_LOADED_OR_DISABLED
+
+          ONLY_WHEN_RUN_AFTER_RULE_IS_LOADED_AND_ENABLED ->
+            VisitorModifier.RunAfterRule.Mode.ONLY_WHEN_RUN_AFTER_RULE_IS_LOADED_AND_ENABLED
+        }
+      )
+
+      RunAsLateAsPossibleCompat -> VisitorModifier.RunAsLateAsPossible
+    }
+  },
+  usesEditorConfigProperties = ruleCompat.usesEditorConfigProperties.mapToSet { shimProperty ->
+    shimProperty.toKtLintProperty120()
+  }
+) {
+
+  override fun beforeFirstNode(editorConfig: EditorConfig) {
+    ruleCompat.beforeFirstNode(EditorConfigCompat120(editorConfig))
+    super.beforeFirstNode(editorConfig)
+  }
+
+  override fun beforeVisitChildNodes(
+    node: ASTNode,
+    autoCorrect: Boolean,
+    emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+  ) {
+    ruleCompat.beforeVisitChildNodes(node, autoCorrect, emit)
+    super.beforeVisitChildNodes(node, autoCorrect, emit)
+  }
+
+  override fun afterVisitChildNodes(
+    node: ASTNode,
+    autoCorrect: Boolean,
+    emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+  ) {
+    ruleCompat.afterVisitChildNodes(node, autoCorrect, emit)
+    super.afterVisitChildNodes(node, autoCorrect, emit)
+  }
+
+  override fun afterLastNode() {
+    ruleCompat.afterLastNode()
+    super.afterLastNode()
+  }
+}

--- a/src/test/kotlin/com/rickbusarow/ktrules/compat/testAlias.kt
+++ b/src/test/kotlin/com/rickbusarow/ktrules/compat/testAlias.kt
@@ -18,17 +18,17 @@ package com.rickbusarow.ktrules.compat
 import com.pinterest.ktlint.rule.engine.api.EditorConfigOverride
 import com.pinterest.ktlint.rule.engine.core.api.RuleProvider
 import com.rickbusarow.ktrules.rules.internal.mapToSet
-import com.rickbusarow.ktrules.toKtLintProperty110
-import com.rickbusarow.ktrules.toKtLintRuleProvider110
+import com.rickbusarow.ktrules.toKtLintProperty120
+import com.rickbusarow.ktrules.toKtLintRuleProvider120
 
 fun EditorConfigOverride.Companion.from(
   vararg properties: Pair<EditorConfigProperty<*>, *>
 ): EditorConfigOverride {
   return EditorConfigOverride.from(
-    *properties.map { it.first.toKtLintProperty110() to it.second }.toTypedArray()
+    *properties.map { it.first.toKtLintProperty120() to it.second }.toTypedArray()
   )
 }
 
-fun Set<RuleProviderCompat>.toKtLintRuleProviders110(): Set<RuleProvider> {
-  return mapToSet { it.toKtLintRuleProvider110() }
+fun Set<RuleProviderCompat>.toKtLintRuleProviders120(): Set<RuleProvider> {
+  return mapToSet { it.toKtLintRuleProvider120() }
 }

--- a/src/test/kotlin/com/rickbusarow/ktrules/rules/Tests.kt
+++ b/src/test/kotlin/com/rickbusarow/ktrules/rules/Tests.kt
@@ -27,7 +27,7 @@ import com.rickbusarow.ktrules.compat.MAX_LINE_LENGTH_PROPERTY
 import com.rickbusarow.ktrules.compat.RuleId
 import com.rickbusarow.ktrules.compat.RuleProviderCompat
 import com.rickbusarow.ktrules.compat.from
-import com.rickbusarow.ktrules.compat.toKtLintRuleProviders110
+import com.rickbusarow.ktrules.compat.toKtLintRuleProviders120
 import com.rickbusarow.ktrules.ec4j.PROJECT_VERSION_PROPERTY
 import com.rickbusarow.ktrules.rules.internal.WrappingStyle
 import com.rickbusarow.ktrules.rules.internal.WrappingStyle.Companion.WRAPPING_STYLE_PROPERTY
@@ -98,7 +98,7 @@ interface Tests : HasDynamicTests {
     val errors = mutableListOf<KtLintTestResult.LintError>()
 
     val outputString = withEngine(
-      ruleProviders = rules.toKtLintRuleProviders110(),
+      ruleProviders = rules.toKtLintRuleProviders120(),
       editorConfig = editorConfig,
       includeAllRules = includeAllRules,
       action = {
@@ -154,7 +154,7 @@ interface Tests : HasDynamicTests {
     editorConfig: EditorConfig?
   ): List<KtLintTestResult.LintError> = buildList {
     withEngine(
-      ruleProviders = rules.toKtLintRuleProviders110(),
+      ruleProviders = rules.toKtLintRuleProviders120(),
       editorConfig = editorConfig,
       includeAllRules = includeAllRules,
       action = fun KtLintRuleEngine.() {


### PR DESCRIPTION
This adds a new compatibility variant for `1.2.x`, a new artifact for `1.1.x`, and updates the default to `1.2.1`