### PR TITLE
chore(renovate): only trigger local renovate action from checkboxes

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,19 +1,19 @@
 name: Renovate
 
 on:
-  schedule:
-    # every 4 hours
-    - cron: "0 */4 * * *"
   workflow_dispatch:
   issues:
-  label:
+    types:
+      - edited
   pull_request:
     types:
-      # run when the little "click here to rebase" box is checked.
-      - synchronize
-  push:
+      - edited
     branches:
-      - main
+      - github-renovate/*
+
+concurrency:
+  group: renovate
+  cancel-in-progress: true
 
 jobs:
   renovate:
@@ -33,7 +33,9 @@ jobs:
           private-key: ${{ secrets.PR_BOT_PRIVATE_KEY }}
 
       - name: Renovate
-        uses: renovatebot/github-action@bdfd950c25796ebf1aa0c127ad55b69a14b04f69 # v43.0.3
+        uses: renovatebot/github-action@a4578d5584ac7a60d0f831537a481de7d00b9260 # v43.0.4
         with:
           configurationFile: .github/renovate-sh.json5
           token: ${{ steps.app-token.outputs.token }}
+        env:
+          LOG_LEVEL: debug


### PR DESCRIPTION
Periodic checks will be handled by the org-wide job.